### PR TITLE
Changing PAM behaviour to stop ugly output on first connection

### DIFF
--- a/scripts/keymaker-create-account-for-iam-user
+++ b/scripts/keymaker-create-account-for-iam-user
@@ -1,17 +1,17 @@
 #!/bin/bash -e
 
-EX_TEMPFAIL=75
-EX_NOPERM=77
 SUPATH='/usr/sbin'
 
 if getent passwd "$PAM_USER" >/dev/null 2>&1; then
     # Terminate the PAM authentication stack. The SSH client will fail since the user didn't supply a valid public key.
-    exit $EX_NOPERM
+    exit $PAM_SUCCESS
 else
     # Create the user, then terminate the PAM authentication stack. The SSH client will fail, and the user will need to try again.
     # TODO: figure out how to display info banner
     # Verify that the IAM user exists.
-    keymaker get_authorized_keys "$PAM_USER" >/dev/null
+    if ! keymaker get_authorized_keys "$PAM_USER" >/dev/null 2>&1; then
+      exit $PAM_SUCCESS
+    fi
     NEW_UID=$(keymaker get_uid "$PAM_USER")
     if ! [ $(command -v useradd > /dev/null) ]; then
         ${SUPATH}/useradd "$PAM_USER" --comment "$PAM_USER" --uid "$NEW_UID" --shell "/bin/bash" --create-home
@@ -21,7 +21,7 @@ else
     for group in $(keymaker get_groups "$PAM_USER"); do
         ${SUPATH}/usermod --append --groups "$group" "$PAM_USER" || echo "$0: Error while adding user to group"
     done
-    echo "Keymaker: Your user account has been replicated onto this host, but SSH will not recognize it until you reconnect."
-    echo "Keymaker: Connect again to log in to your account."
-    exit $EX_TEMPFAIL
+    echo "Keymaker: Your user account has been replicated to this host but cannot be used for this session."
+    echo "Keymaker: Create a new SSH connection."
+    exit $PAM_SUCCESS
 fi


### PR DESCRIPTION
Currently I get this on first connection with a valid IAM user:

```
$ ssh my.user@52.208.162.66
Keymaker: Your user account has been replicated onto this host, but SSH will not recognize it until you reconnect.
Keymaker: Connect again to log in to your account.
/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 75

/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 77

/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 77

Permission denied (publickey,keyboard-interactive).
```

It looks a bit ugly. Even worse for a user that does not exist in IAM:

```
$ ssh bad.user@52.208.162.66
Error while retrieving IAM SSH keys for max.williamsasdasd: An error occurred (NoSuchEntity) when calling the ListSSHPublicKeys operation: The user with name max.williamsasdasd cannot be found.
/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 22

Error while retrieving IAM SSH keys for max.williamsasdasd: An error occurred (NoSuchEntity) when calling the ListSSHPublicKeys operation: The user with name max.williamsasdasd cannot be found.
/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 22

Error while retrieving IAM SSH keys for max.williamsasdasd: An error occurred (NoSuchEntity) when calling the ListSSHPublicKeys operation: The user with name max.williamsasdasd cannot be found.
/usr/local/bin/keymaker-create-account-for-iam-user failed: exit code 22

Permission denied (publickey,keyboard-interactive).
```

So with this PR I change it to:
1. Be silent if user with key does not exist in IAM.
2. Be silent if user is already present on the local system.
3. A nicer message on user creation.