### PR TITLE
Introduce cross-account auth capability and group membership requirement

### DIFF
--- a/keymaker/__init__.py
+++ b/keymaker/__init__.py
@@ -13,6 +13,7 @@ import pwd
 import hashlib
 import codecs
 import grp
+import shlex
 from collections import namedtuple
 
 import boto3  # noqa
@@ -47,7 +48,7 @@ def get_authorized_keys(args):
         _, role_name, instance_id = role_arn.resource.split("/", 2)
         for role_desc_word in re.split("[\s\,]+", iam.get_role(RoleName=role_name)["Role"]["Description"]):
             if role_desc_word.startswith("keymaker_") and role_desc_word.count("=") == 1:
-                config.update([role_desc_word.split("=")])
+                config.update([shlex.split(role_desc_word)[0].split("=")])
     except Exception as e:
         logger.warn(str(e))
     if "keymaker_id_resolver_account" in config:

--- a/keymaker/__init__.py
+++ b/keymaker/__init__.py
@@ -5,6 +5,7 @@ from io import open
 import os
 import sys
 import json
+import re
 import time
 import logging
 import subprocess
@@ -44,7 +45,7 @@ def get_authorized_keys(args):
     try:
         role_arn = parse_arn(sts.get_caller_identity()["Arn"])
         _, role_name, instance_id = role_arn.resource.split("/", 2)
-        for role_desc_word in iam.get_role(RoleName=role_name)["Role"]["Description"].split():
+        for role_desc_word in re.split("[\s\,]+", iam.get_role(RoleName=role_name)["Role"]["Description"]):
             if role_desc_word.startswith("keymaker_") and role_desc_word.count("=") == 1:
                 config.update([role_desc_word.split("=")])
     except Exception as e:


### PR DESCRIPTION
- Cross-account auth is done by introspecting the instance's own IAM
  role description. The description is expected to contain a list of
  space-separated config tokens, for example,
  "keymaker_id_resolver_account=123456789012
  keymaker_id_resolver_role=id_resolver". The role id_resolver in
  account 123456789012 is expected to have a trust policy allowing the
  instance's IAM role to perform sts:AssumeRole on id_resolver.

- Group membership is asserted if the instance's IAM role description
  contains the config token
  "keymaker_require_iam_group=prod_ssh_users". The user logging in is
  then required to be a member of the IAM group "prod_ssh_users".

Tested manually