### PR TITLE
Fall back to a configuration file if role description does not contain config token.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,15 +70,22 @@ Cross-account authentication
 
 Some AWS security models put IAM users in one AWS account, and resources (EC2 instances, S3 buckets, etc.) in a family of other
 federated AWS accounts (for example, a dev account and a prod account). Users then assume roles in those federated accounts,
-subject to their permissions, with `sts:AssumeRole <http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`_. 
+subject to their permissions, with `sts:AssumeRole <http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`_.
 When users connect via SSH to instances running in federated accounts, Keymaker can be instructed to look up the user identity
 and SSH public key in the other AWS account (called the "ID resolver" account).
 
-Keymaker expects to find this configuration information by introspecting the instance's own IAM role description. The
+Keymaker can find this configuration information into two different places :
+- first by introspecting the instance's own IAM role description. The
 description is expected to contain a list of space-separated config tokens, for example,
 ``keymaker_id_resolver_account=123456789012 keymaker_id_resolver_role=id_resolver``. For ``sts:AssumeRole`` to work, the
 role ``id_resolver`` in account 123456789012 is expected to have a trust policy allowing the instance's IAM role to
 perform sts:AssumeRole on ``id_resolver``.
+
+- then if role description does not contain any config token by reading a configuration file located here : `/etc/keymaker/keymaker.config`. Keymaker expect one config token by line.
+```
+keymaker_id_resolver_account=123456789012
+keymaker_id_resolver_role=id_resolver
+```
 
 Run the following command in the ID resolver account (that contains the IAM users) to apply this configuration automatically:
 ``keymaker configure --instance-iam-role arn:aws:iam::987654321098:role/ROLE_NAME --cross-account-profile AWS_CLI_PROFILE_NAME``.

--- a/README.rst
+++ b/README.rst
@@ -74,17 +74,23 @@ subject to their permissions, with `sts:AssumeRole <http://docs.aws.amazon.com/S
 When users connect via SSH to instances running in federated accounts, Keymaker can be instructed to look up the user identity
 and SSH public key in the other AWS account (called the "ID resolver" account).
 
-Keymaker can find this configuration information into two different places :
+Keymaker can find its configuration information into two different places :
 - first by introspecting the instance's own IAM role description. The
 description is expected to contain a list of space-separated config tokens, for example,
 ``keymaker_id_resolver_account=123456789012 keymaker_id_resolver_role=id_resolver``. For ``sts:AssumeRole`` to work, the
 role ``id_resolver`` in account 123456789012 is expected to have a trust policy allowing the instance's IAM role to
 perform sts:AssumeRole on ``id_resolver``.
 
-- then if role description does not contain any config token by reading a configuration file located here : `/etc/keymaker/keymaker.config`. Keymaker expect one config token by line.
-```
-keymaker_id_resolver_account=123456789012
-keymaker_id_resolver_role=id_resolver
+- then if role description does not contain any configuration tokens, Keymaker will search config-token in the following yaml file : `/etc/keymaker/keymaker.yaml`.
+
+Below an example:
+
+```yaml
+---
+keymaker_id_resolver_account: "123456789"
+keymaker_id_resolver_iam_role: "anIamRole"
+keymaker_require_iam_group: "myGroup"
+keymaker_linux_group_prefix: "myPrefix"
 ```
 
 Run the following command in the ID resolver account (that contains the IAM users) to apply this configuration automatically:

--- a/keymaker/__init__.py
+++ b/keymaker/__init__.py
@@ -33,6 +33,7 @@ class ARN(namedtuple("ARN", "partition service region account resource")):
 ARN.__new__.__defaults__ = ("aws", "", "", "", "")
 
 iam_linux_group_prefix = "keymaker_"
+config_file_path = "/etc/keymaker/keymaker.config"
 
 def parse_arn(arn):
     return ARN(*arn.split(":", 5)[1:])
@@ -107,6 +108,16 @@ def parse_keymaker_config(iam_role_description):
     for role_desc_word in re.split("[\s\,]+", iam_role_description or ""):
         if role_desc_word.startswith("keymaker_") and role_desc_word.count("=") == 1:
             config.update([shlex.split(role_desc_word)[0].split("=")])
+
+    if len(config) == 0 and os.path.isfile(config_file_path) :
+        try:
+            config_fd = open(config_file_path, 'r')
+            for line in config_fd:
+                if line.startswith("keymaker_") and line.count("=") == 1:
+                    config.update([shlex.split(line)[0].split("=")])
+        except Exception as e:
+            logger.warn(str(e))
+
     return config
 
 def get_assume_role_session(sts, role_arn):


### PR DESCRIPTION
Keymaker will fall back on a config file if there is no config token present in role description.
See issue https://github.com/kislyuk/keymaker/issues/33