### PR TITLE
Avoid trimming everything if the suffix length is zero

### DIFF
--- a/keymaker/__init__.py
+++ b/keymaker/__init__.py
@@ -400,7 +400,7 @@ def sync_groups(args):
             logger.info("Provisioning group %s from IAM", unix_group_name)
             subprocess.check_call(["groupadd", "--gid", str(aws_to_unix_id(group.group_id)), unix_group_name])
             unix_group = grp.getgrnam(unix_group_name)
-        user_names_in_iam_group = [user.name[:-len(iam_linux_user_suffix)]
+        user_names_in_iam_group = [user.name[:len(user.name)-len(iam_linux_user_suffix)]
                                    for user in group.users.all()
                                    if user.name.endswith(iam_linux_user_suffix)]
         for user in user_names_in_iam_group:


### PR DESCRIPTION
I think this should fix #44 

At the moment, if `iam_linux_user_suffix` is not set, the code ends up effectively trimming the username like so:
```
user.name[:-0]
```
This removes the entire username. Fixed by changing the trim to:
```
user.name[:len(user.name)-len(iam_linux_user_suffix)
```
This should just remove the `iam_linux_user_suffix`. I've made this change manually on a couple of servers and it seems to have resolved the issue and users are now being added to groups.